### PR TITLE
Fix error when adding an unknown prefix

### DIFF
--- a/lib/serialization.js
+++ b/lib/serialization.js
@@ -226,7 +226,11 @@ function serializeElement(node, namespace, prefixMap, requireWellFormed, refs) {
       if (prefix in localPrefixesMap) {
         prefix = attributeUtils.generatePrefix(map, ns, refs.prefixIndex++);
       }
-      map[ns].push(prefix);
+      if (map[ns]) {
+        map[ns].push(prefix);
+      } else {
+        map[ns] = [prefix];
+      }
       qualifiedName = prefix + ":" + node.localName;
       markup += `${qualifiedName} xmlns:${prefix}="${attributeUtils.serializeAttributeValue(
         ns,

--- a/test/wpt/XMLSerializer-serializeToString.test.js
+++ b/test/wpt/XMLSerializer-serializeToString.test.js
@@ -64,4 +64,17 @@ describe("WPT", () => {
       serializer.serializeToString(root)
     );
   });
+
+  test("Check if unknown prefixes are handled correctly", function() {
+    const document = createXmlDoc();
+    const root = document.documentElement;
+    const element = root.ownerDocument.createElementNS(
+      "http://www.w3.org/1999/xhtml",
+      "html:br"
+    );
+    root.appendChild(element);
+    expect(serializer.serializeToString(root, true)).toEqual(
+      '<root><child1>value1</child1><html:br xmlns:html="http://www.w3.org/1999/xhtml" /></root>'
+    );
+  });
 });


### PR DESCRIPTION
A subtest in the [innerhtml-03.xhtml](https://github.com/web-platform-tests/wpt/blob/master/domparsing/innerhtml-03.xhtml#L40) WPT would cause the following error to be thrown during serialization:

`InvalidStateError: Failed to serialize XML: Cannot read property 'push' of undefined`

This resolves it by implementing step 2 of [To add a prefix](https://w3c.github.io/DOM-Parsing/#dfn-add).