### PR TITLE
match web browser implementation of single printing of xmlns attribute

### DIFF
--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -102,6 +102,10 @@ function serializeAttributes(
       }
     }
 
+    if (!requireWellFormed && ignoreNamespaceDefAttr && attr.localName === "xmlns") {
+      continue;
+    }
+
     result += " ";
     if (candidatePrefix !== null) {
       result += candidatePrefix + ":";


### PR DESCRIPTION
Fixes #14 