### PR TITLE
Allow emoji characters as well-formed XML

### DIFF
--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -5,7 +5,7 @@ const xnv = require("xml-name-validator");
 const attributeUtils = require("./attributes");
 const { NAMESPACES, VOID_ELEMENTS, NODE_TYPES } = require("./constants");
 
-const XML_CHAR = /^(\x09|\x0A|\x0D|[\x20-\uD7FF]|[\uE000-\uFFFD]|(?:[\uD800-\uDBFF][\uDC00-\uDFFF]))*$/u;
+const XML_CHAR = /^(\x09|\x0A|\x0D|[\x20-\uD7FF]|[\uE000-\uFFFD]|[\u{10000}-\u{10FFFF}])*$/u;
 const PUBID_CHAR = /^(\x20|\x0D|\x0A|[a-zA-Z0-9]|[-'()+,./:=?;!*#@$_%])*$/u;
 
 function asciiCaseInsensitiveMatch(a, b) {

--- a/test/test.js
+++ b/test/test.js
@@ -167,6 +167,37 @@ describe("Derived from WPT XMLSerializer-serializeToString.html", () => {
   });
 });
 
+describe("Well-formedness test cases", () => {
+  const { DOMParser } = (new JSDOM()).window;
+  const parser = new DOMParser();
+  const document = parser.parseFromString("<dummy />", "text/xml");
+
+  // Derived from https://www.w3.org/TR/xml/#NT-Char
+  test("Check Characters are in range", () => {
+    expect(() => {
+      const emojiNode = document.createTextNode("Emoji 🔍");
+      serialize(emojiNode, { requireWellFormed: true });
+    }).not.toThrow();
+
+    const expectedError = new Error("Failed to serialize XML: text node data is not well-formed.");
+
+    expect(() => {
+      const surrogateBlockNode = document.createTextNode("Surrogate block \uD800");
+      serialize(surrogateBlockNode, { requireWellFormed: true });
+    }).toThrow(expectedError);
+
+    expect(() => {
+      const fffeNode = document.createTextNode("FFFE \uFFFE");
+      serialize(fffeNode, { requireWellFormed: true });
+    }).toThrow(expectedError);
+
+    expect(() => {
+      const ffffNode = document.createTextNode("FFFF \uFFFF");
+      serialize(ffffNode, { requireWellFormed: true });
+    }).toThrow(expectedError);
+  });
+});
+
 describe("Our own test cases", () => {
   const { DOMParser } = (new JSDOM()).window;
 


### PR DESCRIPTION
Resolved https://github.com/jsdom/jsdom/issues/3461 . 

https://github.com/jsdom/w3c-xmlserializer/blob/master/lib/serialize.js#L151
w3c-xmlserializer checks the given XML node is well-formed.
Emoji characters (such as 🔍) are not matched to `XML_CHAR` regular expression.
But, Emoji characters are allowed in well-formed XML according to the [W3C specification](https://www.w3.org/TR/xml/#NT-Char). 

https://github.com/jsdom/w3c-xmlserializer/blob/master/lib/serialize.js#L8
`XML_CHAR` is defined as `/^(\x09|\x0A|\x0D|[\x20-\uD7FF]|[\uE000-\uFFFD]|(?:[\uD800-\uDBFF][\uDC00-\uDFFF]))*$/u`
Because this regular expression uses `u` option, surrogate pair (such as emoji) is not matched.

```node
> (/^(\x09|\x0A|\x0D|[\x20-\uD7FF]|[\uE000-\uFFFD]|(?:[\uD800-\uDBFF][\uDC00-\uDFFF]))*$/u).test("🔍")
   false

```

Surrogate pair is matched by adding `[\u{10000}-\u{10FFFF}]` range. 

```node
> (/^(\x09|\x0A|\x0D|[\x20-\uD7FF]|[\uE000-\uFFFD]|[\u{10000}-\u{10FFFF}])*$/u).test("🔍")
   true

```
